### PR TITLE
Use writeback rather then the default writethrough for compression

### DIFF
--- a/qemu/chroot/step_compress_image.go
+++ b/qemu/chroot/step_compress_image.go
@@ -29,7 +29,7 @@ func (s *StepCompressImage) Run(_ context.Context, state multistep.StateBag) mul
 	ui.Say("Compressing image...")
 	tmpPath := imagePath + ".tmp"
 
-	cmd := fmt.Sprintf("qemu-img convert -c -O qcow2 %s %s", imagePath, tmpPath)
+	cmd := fmt.Sprintf("qemu-img convert -c -t writeback -O qcow2 %s %s", imagePath, tmpPath)
 	cmd, err := wrappedCommand(cmd)
 	if err != nil {
 		err := fmt.Errorf("Error creating compression command: %s", err)


### PR DESCRIPTION
The following PR is to help increase the speed of compression/conversions. The default option is `writethrough`, which is a slower process then `writeback`. For our purposes,  it appears it takes close to 15 minutes, perhaps even more for the compression/conversion to take place. This change is in the attempts to improve the speed of this conversion by switching to use writeback. 

Reference: https://opendev.org/openstack/nova/commit/e7b64eaad82db38dd46f586b650da4ddde42533b
and https://linux.die.net/man/1/qemu-img